### PR TITLE
Adding responsive field to Options

### DIFF
--- a/src/Chartjs/Internal/Encode.elm
+++ b/src/Chartjs/Internal/Encode.elm
@@ -283,6 +283,7 @@ encodeOptions options =
         |> Encode.maybeCustomField "elements" encodeElements options.elements
         |> Encode.maybeCustomField "scales" encodeScales options.scales
         |> Encode.maybeBoolField "maintainAspectRatio" options.maintainAspectRatio
+        |> Encode.maybeBoolField "responsive" options.responsive
         |> Encode.toValue
 
 

--- a/src/Chartjs/Options.elm
+++ b/src/Chartjs/Options.elm
@@ -18,6 +18,7 @@ type alias Options =
     , elements : Maybe Elements.Elements
     , scales : Maybe Scales.Scales
     , maintainAspectRatio : Maybe Bool
+    , responsive : Maybe Bool
     }
 
 
@@ -31,4 +32,5 @@ defaultOptions =
     , elements = Nothing
     , scales = Nothing
     , maintainAspectRatio = Nothing
+    , responsive = Nothing
     }


### PR DESCRIPTION
This allows users to provide an optional responsive boolean that matches Chartjs' options. Partially fixes issue #3.