### PR TITLE
Fix display width and height of canvas for non-responsive charts

### DIFF
--- a/webcomponent/chart.js
+++ b/webcomponent/chart.js
@@ -95,6 +95,12 @@ customElements.define(
 
       this.appendChild(canvasContainer)
       const canvas = this.getElementsByTagName("canvas")[0]
+
+      // Setup the display size of the canvas to match the requested width/height,
+      // this will normally only work if the option responsive field is set to False.
+      canvas.width = this.getAttribute("chartWidth")
+      canvas.height = this.getAttribute("chartHeight")
+
       const ctx = canvas.getContext("2d")
       this._chart = new Chart(ctx, this._chartConfig)
     }


### PR DESCRIPTION
This is the final fix for #3 to properly set the canvas size when using a non-responsive chart. If responsive is used, this width and height seem to be ignored and the chart should properly size to the window dimensions.

Per this [SO answer](https://stackoverflow.com/a/43364730) using the JS approach should properly change the display size of the canvas. This is used rather than the chart attribute approach since it would technically affect the drawing buffer. Although visually these looked the same, it seems the former approach is probably the better approach.

This change is needed, as it seems the default width/height of the [canvas is 300x150](https://stackoverflow.com/a/12019582).